### PR TITLE
Updating go.mod for go install github.com/... usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module dapp-pm
+module github.com/hjubb/dapp-pm
 
 go 1.15
 


### PR DESCRIPTION
Attempted to use this library via `go install github.com/hjubb/dapp-pm` & it failed.

Validating using my own fork & it works.