### PR TITLE
Updating dependency traversal to accomodate large tree depth

### DIFF
--- a/git.go
+++ b/git.go
@@ -1,2 +1,1 @@
 package main
-

--- a/model_test.go
+++ b/model_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"reflect"
 	"testing"
+	"github.com/emirpasic/gods/sets/hashset"
 )
 
 func TestNewDependency(t *testing.T) {
@@ -32,6 +33,61 @@ func TestNewDependency(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewDependency() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestGetDependencies(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    int
+		wantErr bool
+	}{
+		{name: "test works", want: 8, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+      // level 2
+      d := &Sol{name: "D", path: "./D", deps: make([]*Sol, 0)}
+      e := &Sol{name: "E", path: "./E", deps: make([]*Sol, 0)}
+      f := &Sol{name: "F", path: "./F", deps: make([]*Sol, 0)}
+      g := &Sol{name: "G", path: "./G", deps: make([]*Sol, 0)}
+
+      // level 1
+      a := &Sol{name: "A", path: "./A", deps: []*Sol{d, e}}
+      b := &Sol{name: "B", path: "./B", deps: []*Sol{f}}
+      c := &Sol{name: "C", path: "./C", deps: []*Sol{g}}
+
+      root := &Sol{
+        name: "X", path: "./X", deps: []*Sol{a, b, c},
+      }
+      GetDependenciesOld := func(selected *Sol) (*hashset.Set){
+        inclDeps := hashset.New()
+        selections := hashset.New()
+        selections.Add(selected)
+        for _, inter := range selections.Values() {
+          sol := inter.(*Sol)
+          inclDeps.Add(sol)
+          for _, dep := range sol.deps {
+            inclDeps.Add(dep)
+          }
+        }
+        return inclDeps
+      }
+      oldResults := len(GetDependenciesOld(root).Values())
+
+      results, err := GetDependencies(root)
+      uniqueDeps := len(results.Values())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDependencies() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+      if uniqueDeps != tt.want {
+				t.Errorf("GetDependencies() got = %v, want %v", uniqueDeps, tt.want)
+      }
+      if uniqueDeps < oldResults {
+				t.Errorf("GetDependencies() got = %v, OldWay got %v", uniqueDeps, oldResults)
+      }
 		})
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"github.com/emirpasic/gods/sets/hashset"
 	"reflect"
 	"testing"
-	"github.com/emirpasic/gods/sets/hashset"
 )
 
 func TestNewDependency(t *testing.T) {
@@ -47,47 +47,47 @@ func TestGetDependencies(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-      // level 2
-      d := &Sol{name: "D", path: "./D", deps: make([]*Sol, 0)}
-      e := &Sol{name: "E", path: "./E", deps: make([]*Sol, 0)}
-      f := &Sol{name: "F", path: "./F", deps: make([]*Sol, 0)}
-      g := &Sol{name: "G", path: "./G", deps: make([]*Sol, 0)}
+			// level 2
+			d := &Sol{name: "D", path: "./D", deps: make([]*Sol, 0)}
+			e := &Sol{name: "E", path: "./E", deps: make([]*Sol, 0)}
+			f := &Sol{name: "F", path: "./F", deps: make([]*Sol, 0)}
+			g := &Sol{name: "G", path: "./G", deps: make([]*Sol, 0)}
 
-      // level 1
-      a := &Sol{name: "A", path: "./A", deps: []*Sol{d, e}}
-      b := &Sol{name: "B", path: "./B", deps: []*Sol{f}}
-      c := &Sol{name: "C", path: "./C", deps: []*Sol{g}}
+			// level 1
+			a := &Sol{name: "A", path: "./A", deps: []*Sol{d, e}}
+			b := &Sol{name: "B", path: "./B", deps: []*Sol{f}}
+			c := &Sol{name: "C", path: "./C", deps: []*Sol{g}}
 
-      root := &Sol{
-        name: "X", path: "./X", deps: []*Sol{a, b, c},
-      }
-      GetDependenciesOld := func(selected *Sol) (*hashset.Set){
-        inclDeps := hashset.New()
-        selections := hashset.New()
-        selections.Add(selected)
-        for _, inter := range selections.Values() {
-          sol := inter.(*Sol)
-          inclDeps.Add(sol)
-          for _, dep := range sol.deps {
-            inclDeps.Add(dep)
-          }
-        }
-        return inclDeps
-      }
-      oldResults := len(GetDependenciesOld(root).Values())
+			root := &Sol{
+				name: "X", path: "./X", deps: []*Sol{a, b, c},
+			}
+			GetDependenciesOld := func(selected *Sol) *hashset.Set {
+				inclDeps := hashset.New()
+				selections := hashset.New()
+				selections.Add(selected)
+				for _, inter := range selections.Values() {
+					sol := inter.(*Sol)
+					inclDeps.Add(sol)
+					for _, dep := range sol.deps {
+						inclDeps.Add(dep)
+					}
+				}
+				return inclDeps
+			}
+			oldResults := len(GetDependenciesOld(root).Values())
 
-      results, err := GetDependencies(root)
-      uniqueDeps := len(results.Values())
+			results, err := GetDependencies(root)
+			uniqueDeps := len(results.Values())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDependencies() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-      if uniqueDeps != tt.want {
+			if uniqueDeps != tt.want {
 				t.Errorf("GetDependencies() got = %v, want %v", uniqueDeps, tt.want)
-      }
-      if uniqueDeps < oldResults {
+			}
+			if uniqueDeps < oldResults {
 				t.Errorf("GetDependencies() got = %v, OldWay got %v", uniqueDeps, oldResults)
-      }
+			}
 		})
 	}
 }

--- a/storage.go
+++ b/storage.go
@@ -41,24 +41,24 @@ func NewStorageEngine() (*Storage, error) {
 
 func GetDependencies(s *Sol) (*hashset.Set, error) {
 	allDeps := hashset.New()
-  allDeps.Add(s)
-  if len(s.deps) == 0 {
-    return allDeps, nil
-  }
+	allDeps.Add(s)
+	if len(s.deps) == 0 {
+		return allDeps, nil
+	}
 
-  for _, dep := range s.deps {
-    result, err := GetDependencies(dep)
+	for _, dep := range s.deps {
+		result, err := GetDependencies(dep)
 
-    if err != nil {
-      panic(err)
-    }
+		if err != nil {
+			panic(err)
+		}
 
-    for _, some_dep := range result.Values(){
-      allDeps.Add(some_dep)
-    }
-  }
+		for _, some_dep := range result.Values() {
+			allDeps.Add(some_dep)
+		}
+	}
 
-  return allDeps, nil
+	return allDeps, nil
 }
 
 func (s *Storage) CheckExisting(dep *Dependency) (bool, error) {
@@ -229,10 +229,10 @@ func (s *Storage) Commit(e *Extractor, set *hashset.Set) {
 	for _, inter := range set.Values() {
 		sol := inter.(*Sol)
 		inclDeps.Add(sol)
-    deps, err := GetDependencies(sol)
-    if err != nil {
-      panic(err)
-    }
+		deps, err := GetDependencies(sol)
+		if err != nil {
+			panic(err)
+		}
 		for _, dep := range deps.Values() {
 			inclDeps.Add(dep)
 		}

--- a/storage.go
+++ b/storage.go
@@ -39,6 +39,28 @@ func NewStorageEngine() (*Storage, error) {
 	}, nil
 }
 
+func GetDependencies(s *Sol) (*hashset.Set, error) {
+	allDeps := hashset.New()
+  allDeps.Add(s)
+  if len(s.deps) == 0 {
+    return allDeps, nil
+  }
+
+  for _, dep := range s.deps {
+    result, err := GetDependencies(dep)
+
+    if err != nil {
+      panic(err)
+    }
+
+    for _, some_dep := range result.Values(){
+      allDeps.Add(some_dep)
+    }
+  }
+
+  return allDeps, nil
+}
+
 func (s *Storage) CheckExisting(dep *Dependency) (bool, error) {
 	s.fetchMut.RLock()
 	defer s.fetchMut.RUnlock()
@@ -207,7 +229,11 @@ func (s *Storage) Commit(e *Extractor, set *hashset.Set) {
 	for _, inter := range set.Values() {
 		sol := inter.(*Sol)
 		inclDeps.Add(sol)
-		for _, dep := range sol.deps {
+    deps, err := GetDependencies(sol)
+    if err != nil {
+      panic(err)
+    }
+		for _, dep := range deps.Values() {
 			inclDeps.Add(dep)
 		}
 	}


### PR DESCRIPTION
Originally attempted to use [ERC721.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol) contract via this package manager but since the tree height > 2, it missed `IERC165.sol` which caused `solc` to throw an error due to a missing file.

Introducing recursion for the flattening of the dependency tree into the hashset which is then used to iterate through to write to the filesystem.

Added tests to validate it works as intended while also doing a mini test compare vs old method to assist in reviewing.